### PR TITLE
サーバーにユーザー登録とログインできるように機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "24.3.0",
+        "@types/react": "19.1.12",
         "ffmpeg-static": "^5.2.0",
         "fluent-ffmpeg": "^2.1.3",
         "tailwindcss": "^4",
@@ -3477,11 +3478,10 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
-      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "version": "19.1.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
+      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "24.3.0",
+    "@types/react": "19.1.12",
     "ffmpeg-static": "^5.2.0",
     "fluent-ffmpeg": "^2.1.3",
     "tailwindcss": "^4",

--- a/src/app/login/owner/page.jsx
+++ b/src/app/login/owner/page.jsx
@@ -1,55 +1,108 @@
-'use client';
+"use client";
 
 // 経営者のログイン画面
 // CSSファイルの読み込み
-import styles from '@/styles/approvals.module.css';
+import styles from "@/styles/approvals.module.css";
 
 // コンポーネント読み込み
-import ApprovalsButton from '@/components/atoms/approvalsButton';
-import ApprovalsInput from '@/components/atoms/ApprovalsInput';
+import ApprovalsButton from "@/components/atoms/ApprovalsButton";
+import ApprovalsInput from "@/components/atoms/ApprovalsInput";
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+
 export default function LoginPage() {
   // ページ遷移用のフック
   const router = useRouter();
+  const [loading, setLoading] = useState(false);
 
   // 入力値を状態管理
-  const [userId, setUserId] = useState('');
-  const [password, setPassword] = useState('');
+  const [userId, setUserId] = useState("");
+  const [password, setPassword] = useState("");
 
   //ログインボタンを押したときの処理
-  function login(e){
-    // ページリロードを防ぐ
+  const login = async (e) => {
     e.preventDefault();
+    if (loading) return;
 
-    console.log("ログインボタンが押されました。");
-    console.log("入力ID:", userId);
-    console.log("入力PW:", password);
+    setLoading(true);
+    try {
+      if (!userId || !password) {
+        alert("ID と パスワードを入力してください。");
+        setLoading(false);
+        return;
+      }
 
-    console.log("ログインボタンが押されました。");
-    
-    // 店舗一覧画面に遷移
-    router.push("/owner/stores");
-  }
+      const response = await fetch(`${API_BASE_URL}/api/auth/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // バックエンドの期待に合わせてキー名は loginId / password
+        body: JSON.stringify({ loginId: userId, password }),
+      });
+
+      if (!response.ok) {
+        // レスポンスの形式が JSON/テキスト どちらでも拾えるようにする
+        const contentType = response.headers.get("content-type") || "";
+        const msg = contentType.includes("application/json")
+          ? (await response.json())?.message ?? "ログインに失敗しました"
+          : await response.text();
+
+        if (String(msg).includes("ログイン失敗")) {
+          alert("※ユーザー名またはパスワードが間違っています");
+        } else {
+          alert(String(msg));
+        }
+        setLoading(false);
+        return;
+      }
+      const result = await response.json();
+      const accessToken = result.accessToken;
+      const refreshToken = result.refreshToken;
+
+      if (accessToken) localStorage.setItem("accessToken", accessToken);
+      if (refreshToken) localStorage.setItem("refreshToken", refreshToken);
+
+      // 成功後に遷移
+      router.push("/owner/stores");
+    } catch (err) {
+      console.error(err);
+      alert("ログインに失敗しました。もう一度お試しください。");
+      setLoading(false);
+    }
+  };
 
   return (
     <div className={styles.div}>
       <form className={styles.loginForm} onSubmit={login}>
         <h2 className={styles.h2}>ログイン</h2>
-        
+
         {/* ユーザーID */}
-        <ApprovalsInput type="text" name='userId' id='userId' text="ID"
-        onChange={(e) => setUserId(e.target.value)}/>
+        <ApprovalsInput
+          type="text"
+          name="userId"
+          id="userId"
+          text="ID"
+          onChange={(e) => setUserId(e.target.value)}
+        />
 
         {/* password */}
-        <ApprovalsInput type="password" name='password' id='password' text="パスワード"
-        onChange={(e) => setPassword(e.target.value)}
+        <ApprovalsInput
+          type="password"
+          name="password"
+          id="password"
+          text="パスワード"
+          onChange={(e) => setPassword(e.target.value)}
         />
 
         {/* ログインボタン */}
-        <ApprovalsButton type="submit" text="ログイン"/>
+        <ApprovalsButton
+          type="submit"
+          text={loading ? "ログイン中..." : "ログイン"}
+          disabled={loading}
+        />
       </form>
 
       <p>アカウントが未登録ですか？</p>

--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -1,45 +1,91 @@
-// ユーザーのログイン画面
-// CSSファイルの読み込み
-
 'use client';
-import { useRouter } from 'next/navigation'; // App Router用のルーター
-import styles from '@/styles/approvals.module.css';
 
-// コンポーネント読み込み
-import ApprovalsButton from '@/components/atoms/approvalsButton';
+import styles from '@/styles/approvals.module.css';
+import ApprovalsButton from '@/components/atoms/ApprovalsButton';
 import ApprovalsInput from '@/components/atoms/ApprovalsInput';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 export default function LoginPage() {
   const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080';
 
-  //ログインボタンを押したときの処理
-  function login(e){
-    e.preventDefault(); // ページリロード防止
-    console.log("ログインボタンが押されました。");
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (loading) return;
 
-    // 認証処理がここに入る（API呼び出しなど）
+    setLoading(true);
+    try {
+      const form = new FormData(e.currentTarget);
+      // ApprovalsInput に渡している name をそのまま使う
+      const userId = String(form.get('userId') ?? '');
+      const password = String(form.get('password') ?? '');
 
-    // 認証後に遷移（店舗一覧画面へ）
-    router.push('/store/list');
-  }
+      if (!userId || !password) {
+        alert('ID と パスワードを入力してください。');
+        setLoading(false);
+        return;
+      }
+
+      const response = await fetch(`${API_BASE_URL}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // バックエンドの期待に合わせてキー名は loginId / password
+        body: JSON.stringify({ loginId: userId, password }),
+      });
+
+      if (!response.ok) {
+        // レスポンスの形式が JSON/テキスト どちらでも拾えるようにする
+        const contentType = response.headers.get('content-type') || '';
+        const msg = contentType.includes('application/json')
+          ? (await response.json())?.message ?? 'ログインに失敗しました'
+          : await response.text();
+
+        if (String(msg).includes('ログイン失敗')) {
+          alert('※ユーザー名またはパスワードが間違っています');
+        } else {
+          alert(String(msg));
+        }
+        setLoading(false);
+        return;
+      }
+
+      const result = await response.json();
+      const accessToken = result.accessToken;
+      const refreshToken = result.refreshToken;
+
+      if (accessToken) localStorage.setItem('accessToken', accessToken);
+      if (refreshToken) localStorage.setItem('refreshToken', refreshToken);
+
+      // 成功後に遷移
+      router.push('/store/list');
+    } catch (err) {
+      console.error(err);
+      alert('ログインに失敗しました。もう一度お試しください。');
+      setLoading(false);
+    }
+  };
 
   return (
     <div className={styles.div}>
-      <form className={styles.loginForm} onSubmit={login}>
+      <form className={styles.loginForm} onSubmit={handleSubmit}>
         <h2 className={styles.h2}>ログイン</h2>
-        
-        {/* ユーザーID */}
-        <ApprovalsInput type="text" name='userId' id='userId' text="ID"/>
 
-        {/* password */}
-        <ApprovalsInput type="password" name='password' id='password' text="パスワード"/>
+        {/* ユーザーID */}
+        <ApprovalsInput type="text" name="userId" id="userId" text="ID" required />
+
+        {/* パスワード */}
+        <ApprovalsInput type="password" name="password" id="password" text="パスワード" required />
 
         {/* ログインボタン */}
-        <ApprovalsButton type="submit" text="ログイン"/>
+        {/* onClick は不要。type="submit" で送信される */}
+        <ApprovalsButton type="submit" text={loading ? 'ログイン中...' : 'ログイン'} disabled={loading} />
       </form>
 
       <p>アカウントが未登録ですか？</p>
-      <a href={"/register"}>アカウント作成</a>
+      <a href="/register">アカウント作成</a>
     </div>
   );
 }

--- a/src/app/register/owner/page.jsx
+++ b/src/app/register/owner/page.jsx
@@ -1,92 +1,142 @@
-//　経営者側の新規登録画面
-// CSSファイルの読み込み
-'use client';
+// 経営者側の新規登録
+"use client";
 
-import { useRouter } from 'next/navigation'; 
-import React , { useState }from 'react';
-import styles from '@/styles/approvals.module.css';
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+import styles from "@/styles/approvals.module.css";
 
-// コンポーネント読み込み
-import ApprovalsButton from '@/components/atoms/approvalsButton';
-import ApprovalsInput from '@/components/atoms/ApprovalsInput';
-import ConfirmModal from '@/components/atoms/ConfirmModal'; //確認モーダル用
+import ApprovalsButton from "@/components/atoms/ApprovalsButton";
+import ApprovalsInput from "@/components/atoms/ApprovalsInput";
+import ConfirmModal from "@/components/atoms/ConfirmModal";
 
-export default function LoginPage() {
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+
+export default function OwnerRegisterPage() {
   const router = useRouter();
+  const [loading, setLoading] = useState(false);
 
-  // 入力状態を管理
-  const [name, setName] = useState('');
-  const [userId, setUserId] = useState('');
-  const [password, setPassword] = useState('');
+  // 入力状態
+  const [name, setName] = useState("");
+  const [userId, setUserId] = useState("");
+  const [password, setPassword] = useState("");
   const [showModal, setShowModal] = useState(false);
-  
-  // 戻るボタンのクリック時に前のページへ戻る関数
+
   const handleBack = () => {
-    router.push('/login/owner'); // 1つ前のページに戻る
-    console.log("戻るボタン");
+    router.push("/login/owner");
   };
-  
-  // 登録ボタンを押したらモーダルを表示
+
+  // まずモーダルを開く
   const handleSubmit = (e) => {
     e.preventDefault();
     setShowModal(true);
   };
-  
-  // モーダルで「OK」押したときの登録処理
-  const handleConfirm = () => {
-    setShowModal(false);
-    console.log('登録ボタン', { userId, password });
-    // API呼び出しなど行う
-  
-    // ▼ 登録完了したらログイン画面へ戻る
-    router.push('/login/owner');
-  };
 
- 
-  // 登録ボタン
-  // function rigister(){
-  //   console.log("登録ボタン");
-  // }
+  // モーダルOK時の実処理
+  const handleConfirm = async () => {
+    if (loading) return;
+
+    if (!userId || !password || !name) {
+      alert("名前 と ID と パスワードを入力してください。");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/auth/owner`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ loginId: userId, password, userName: name }),
+      });
+
+      if (!res.ok) {
+        const ct = res.headers.get("content-type") || "";
+        const msg = ct.includes("application/json")
+          ? (await res.json())?.message ?? "登録に失敗しました"
+          : await res.text();
+
+        if (
+          String(msg).includes("既に存在") ||
+          String(msg).includes("すでに")
+        ) {
+          alert("※このIDはすでに使用されています");
+        } else {
+          alert(String(msg));
+          console.error("register error:", msg);
+        }
+        return;
+      }
+
+      alert("登録が完了しました。");
+      router.push("/login/owner");
+    } catch (err) {
+      console.error("登録エラー:", err);
+      alert("登録に失敗しました。");
+    } finally {
+      setLoading(false);
+      setShowModal(false);
+    }
+  };
 
   return (
     <>
-    <div className={styles.div}>
-      <button className={styles.backbutton} onClick={handleBack}>←</button>
-      <form className={styles.loginForm} onSubmit={handleSubmit}>
-        <h2 className={styles.h2}>経営者新規アカウント登録</h2>
-        
-        {/* ユーザー氏名 */}
-        <ApprovalsInput type="text" name='name' id='name' text="ユーザー氏名"
-          value={name}
-          onChange={(e) => setName(e.target.value)}/>
+      <div className={styles.div}>
+        <button className={styles.backbutton} onClick={handleBack}>
+          ←
+        </button>
 
-        {/* ユーザーID */}
-        <ApprovalsInput type="text" name='userId' id='userId' text="ID(半角英数字のみ)"
-          value={userId}
-          onChange={(e) => setUserId(e.target.value)}/>
+        <form className={styles.loginForm} onSubmit={handleSubmit}>
+          <h2 className={styles.h2}>経営者新規アカウント登録</h2>
 
-        {/* password */}
-        <ApprovalsInput type="password" name='password' id='password' text="パスワード(半角英数字のみ)"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}/>
+          <ApprovalsInput
+            type="text"
+            name="name"
+            id="name"
+            text="ユーザー氏名"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
 
-        {/* 登録ボタン */}
-        <ApprovalsButton type="submit" text="登録"/>
-      </form>
-    </div>
+          <ApprovalsInput
+            type="text"
+            name="userId"
+            id="userId"
+            text="ID(半角英数字のみ)"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            required
+          />
 
-    {/* モーダルはここ。画面全体の上に表示されるように親divの外 */}
-    {showModal && (
-      <ConfirmModal
-        fields={[
-          { label: 'ユーザ氏名', value: name },
-          { label: 'ID(半角英数字のみ)', value: userId },
-          { label: 'パスワード(半角英数字のみ)', value: password },
-        ]}
-        onConfirm={handleConfirm}
-        onCancel={() => setShowModal(false)}
-      />
-    )}
+          <ApprovalsInput
+            type="password"
+            name="password"
+            id="password"
+            text="パスワード(半角英数字のみ)"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+
+          <ApprovalsButton
+            type="submit"
+            text={loading ? "登録中…" : "登録"}
+            disabled={loading}
+          />
+        </form>
+      </div>
+
+      {showModal && (
+        <ConfirmModal
+          fields={[
+            { label: "ユーザ氏名", value: name },
+            { label: "ID(半角英数字のみ)", value: userId },
+            { label: "パスワード(半角英数字のみ)", value: password },
+          ]}
+          onConfirm={handleConfirm}
+          onCancel={() => setShowModal(false)}
+        />
+      )}
     </>
   );
 }

--- a/src/app/register/page.jsx
+++ b/src/app/register/page.jsx
@@ -1,89 +1,105 @@
-//　利用者側の新規登録画面
-// CSSファイルの読み込み
 'use client';
 
-import { useRouter } from 'next/navigation'; 
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import styles from '@/styles/approvals.module.css';
 
-// コンポーネント読み込み
-import ApprovalsButton from '@/components/atoms/approvalsButton';
+import ApprovalsButton from '@/components/atoms/ApprovalsButton';
 import ApprovalsInput from '@/components/atoms/ApprovalsInput';
-import ConfirmModal from '@/components/atoms/ConfirmModal'; //確認モーダル用
 
-export default function LoginPage() {
+export default function RegisterPage() {
   const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080';
 
-  
-  // 入力状態を管理
-  const [userId, setUserId] = useState('');
-  const [password, setPassword] = useState('');
-  const [showModal, setShowModal] = useState(false);
-
-  // 戻るボタンのクリック時に前のページへ戻る関数
-   const handleBack = () => {
-    router.push('/login'); 
-    //console.log("戻るボタン");
-  };
-
-  // 登録ボタンを押したらモーダルを表示
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    setShowModal(true);
-  };
-
-  // モーダルで「OK」押したときの登録処理
-  const handleConfirm = () => {
-    setShowModal(false);
-    console.log('登録ボタン', { userId, password });
-    // API呼び出しなど行う
-
-    // ▼ 登録完了したらログイン画面へ戻る
+  // 戻る
+  const handleBack = () => {
     router.push('/login');
   };
 
-  // モーダルで「戻る」押したとき
-  const handleCancel = () => {
-    setShowModal(false);
+  // 送信（登録）
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (loading) return;
+
+    const form = new FormData(e.currentTarget);
+    const userId = String(form.get('userId') || '');
+    const password = String(form.get('password') || '');
+
+    if (!userId || !password) {
+      alert('ID と パスワードを入力してください。');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/auth`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // バックエンド仕様に合わせてキーは loginId / password
+        body: JSON.stringify({ loginId: userId, password }),
+      });
+
+      if (!response.ok) {
+        const contentType = response.headers.get('content-type') || '';
+        const msg = contentType.includes('application/json')
+          ? (await response.json())?.message ?? '登録に失敗しました'
+          : await response.text();
+
+        if (String(msg).includes('既に存在') || String(msg).includes('すでに')) {
+          alert('※このユーザー名はすでに使用されています');
+        } else {
+          alert(String(msg));
+          console.error('register error:', msg);
+        }
+        setLoading(false);
+        return;
+      }
+
+      alert('登録が完了しました。');
+      router.push('/login'); // 登録完了後にログインへ
+    } catch (err) {
+      console.error('登録エラー:', err);
+      alert('登録に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
   };
-  
-  // 登録ボタン
-  //function rigister(){
-    //console.log("登録ボタン");
-  //}
+
   return (
-    <>
-      <div className={styles.div}>
+    <div className={styles.div}>
       <button className={styles.backbutton} onClick={handleBack}>←</button>
+
+      {/* onSubmit をフォームにセット */}
       <form className={styles.loginForm} onSubmit={handleSubmit}>
         <h2 className={styles.h2}>新規アカウント登録</h2>
-        
-        {/* ユーザーID */}
-        <ApprovalsInput type="text" name='userId' id='userId' text="ID(半角英数字のみ)"
-          value={userId}
-          onChange={(e) => setUserId(e.target.value)}/>
 
-        {/* password */}
-        <ApprovalsInput type="password" name='password' id='password' text="パスワード(半角英数字のみ)"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}/>
+        {/* ユーザーID（name が FormData で拾われます） */}
+        <ApprovalsInput
+          type="text"
+          name="userId"
+          id="userId"
+          text="ID(半角英数字のみ)"
+          required
+        />
 
-        {/* 登録ボタン */}
-        <ApprovalsButton type="submit" text="登録"/>
+        {/* パスワード */}
+        <ApprovalsInput
+          type="password"
+          name="password"
+          id="password"
+          text="パスワード(半角英数字のみ)"
+          required
+        />
+
+        {/* 登録ボタン。onClick は不要、type=submit で送信 */}
+        <ApprovalsButton
+          type="submit"
+          text={loading ? '登録中…' : '登録'}
+          disabled={loading}
+        />
       </form>
     </div>
-
-    {/* モーダルはここ。画面全体の上に表示されるように親divの外 */}
-    {showModal && (
-      <ConfirmModal
-        fields={[
-          { label: 'ID(半角英数字のみ)', value: userId },
-          { label: 'パスワード(半角英数字のみ)', value: password },
-        ]}
-        onConfirm={handleConfirm}
-        onCancel={handleCancel}
-      />
-    )}
-    </>
   );
 }


### PR DESCRIPTION
## 変更の概要
サーバーにユーザー登録とログインできるように機能を追加

## なぜこの変更をするのか
サーバーとの連結のため

## やったこと
fetchを使ってサーバーとの通信できるようにして、新規登録とログイン機能を追加

## 変更内容
app/login/owner/page.jsx：経営者のログイン処理を追加し、アクセストークンとリフレッシュトークンをlocalStoregeに保存できる機能を追加
app/login/page.jsx：利用者のログイン処理を追加し、アクセストークンとリフレッシュトークンをlocalStoregeに保存できる機能を追加
app/register/owner：経営者の新規登録機能を追加
app/register：利用者の新規登録機能を追加

## 確認事項
ログインした際に、検証を開いてアクセストークンとリフレッシュトークンが保存されていることを確認してください。
<img width="954" height="110" alt="image" src="https://github.com/user-attachments/assets/7330b1e2-9dc0-4337-b2cf-9b193644f4c3" />